### PR TITLE
Add an atlas file to stitch files from textures/ctm/ to the block atl…

### DIFF
--- a/src/main/resources/assets/minecraft/atlases/blocks.json
+++ b/src/main/resources/assets/minecraft/atlases/blocks.json
@@ -1,0 +1,9 @@
+{
+  "sources": [
+    {
+      "type": "directory",
+      "source": "ctm",
+      "prefix": "ctm/"
+    }
+  ]
+}


### PR DESCRIPTION
…as so that mods can trivially only have their ctm textures stitched to the atlas when CTM is present